### PR TITLE
display entire file diff argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: review
 Title: QC Management and Helpers
-Version: 3.9.1
+Version: 3.9.1.9000
 Authors@R: 
     c(
     person(given = "Eric", family = "Anderson", email = "andersone@metrumrg.com", role = c("aut")),
@@ -14,7 +14,7 @@ BugReports: https://github.com/metrumresearchgroup/review/issues
 License: GPL (>= 3)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Imports: 
     dplyr,
     magrittr (>= 2.0.3),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Authors@R:
     )
 Description: Functions for managing logs of reviews of subversioned
         files (http://subversion.apache.org/).
-URL: https://github.com/metrumresearchgroup/review
+URL: https://github.com/metrumresearchgroup/review, https://metrumresearchgroup.github.io/review/
 BugReports: https://github.com/metrumresearchgroup/review/issues
 License: GPL (>= 3)
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# review development
+
+## New features and changes
+
+- `diffFiles` can now display the entire file that is being diffed. ()
+
 # review 3.9.1
 
 ## New features and changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## New features and changes
 
-- `diffFiles` can now display the entire file that is being diffed. ()
+- `diffFiles` can now display the entire file that is being diffed. (#115)
 
 # review 3.9.1
 

--- a/R/diffFiles.R
+++ b/R/diffFiles.R
@@ -14,6 +14,7 @@
 #' @param .banner_2 Header for second file in viewer
 #' @param .side_by_side Logical. Should diffs be displayed side by side?
 #' @param .ignore_white_space Logical. Should white space be ignored?
+#' @param .display_entire_file Logical. Should the entire file be displayed?
 #' @examples 
 #' with_demoRepo({
 #'  diffFiles(.file_1 = "script/data-assembly.R", 
@@ -26,7 +27,8 @@ diffFiles <- function(.file_1,
                       .banner_1 = NULL,
                       .banner_2 = NULL,
                       .side_by_side = TRUE,
-                      .ignore_white_space = FALSE) {
+                      .ignore_white_space = FALSE,
+                      .display_entire_file = FALSE) {
   
   if (is.null(.banner_1)) {
     .banner_1 = basename(.file_1)
@@ -43,7 +45,8 @@ diffFiles <- function(.file_1,
     mode = ifelse(.side_by_side, "sidebyside", "unified"),
     tar.banner = .banner_1,
     cur.banner = .banner_2,
-    ignore.white.space = .ignore_white_space
+    ignore.white.space = .ignore_white_space,
+    context = ifelse(.display_entire_file, -1, 2)
   )
   
 }

--- a/R/diffPreviousRevisions.R
+++ b/R/diffPreviousRevisions.R
@@ -10,6 +10,7 @@
 #' @param .current_revision current revision (defaults to local copy)
 #' @param .side_by_side Logical. Should diffs be displayed side by side?
 #' @param .ignore_white_space Logical. Should white space be ignored?
+#' @param .display_entire_file Logical. Should the entire file be displayed?
 #' 
 #' @examples 
 #' with_demoRepo({
@@ -22,7 +23,8 @@ diffPreviousRevisions <- function(.file,
                                   .previous_revision,
                                   .current_revision = NULL,
                                   .side_by_side = TRUE,
-                                  .ignore_white_space = FALSE){
+                                  .ignore_white_space = FALSE,
+                                  .display_entire_file = FALSE){
 
   previousCurrent <-
     getPreviousCurrent(
@@ -42,7 +44,8 @@ diffPreviousRevisions <- function(.file,
     .banner_1 = previousCurrent$.previous_revision_header,
     .banner_2 = previousCurrent$.current_revision_header, 
     .side_by_side = .side_by_side, 
-    .ignore_white_space = .ignore_white_space 
+    .ignore_white_space = .ignore_white_space,
+    .display_entire_file = .display_entire_file
   )
   
 }

--- a/R/diffQced.R
+++ b/R/diffQced.R
@@ -8,6 +8,7 @@
 #' @param .file file path from working directory
 #' @param .side_by_side Logical. Should diffs be displayed side by side?
 #' @param .ignore_white_space Logical. Should white space be ignored?
+#' @param .display_entire_file Logical. Should the entire file be displayed?
 #' 
 #' @examples 
 #' with_demoRepo({
@@ -15,7 +16,10 @@
 #' })
 #' 
 #' @export
-diffQced <- function(.file, .side_by_side = TRUE, .ignore_white_space = FALSE){
+diffQced <- function(.file,
+                     .side_by_side = TRUE,
+                     .ignore_white_space = FALSE,
+                     .display_entire_file = FALSE){
   
   up_to_date <-
     tryCatch(
@@ -57,7 +61,8 @@ diffQced <- function(.file, .side_by_side = TRUE, .ignore_white_space = FALSE){
     .file = .file, 
     .previous_revision = qced_revision,
     .side_by_side = .side_by_side, 
-    .ignore_white_space = .ignore_white_space
+    .ignore_white_space = .ignore_white_space,
+    .display_entire_file = .display_entire_file
   )
   
 }

--- a/man/diffFiles.Rd
+++ b/man/diffFiles.Rd
@@ -10,7 +10,8 @@ diffFiles(
   .banner_1 = NULL,
   .banner_2 = NULL,
   .side_by_side = TRUE,
-  .ignore_white_space = FALSE
+  .ignore_white_space = FALSE,
+  .display_entire_file = FALSE
 )
 }
 \arguments{
@@ -25,6 +26,8 @@ diffFiles(
 \item{.side_by_side}{Logical. Should diffs be displayed side by side?}
 
 \item{.ignore_white_space}{Logical. Should white space be ignored?}
+
+\item{.display_entire_file}{Logical. Should the entire file be displayed?}
 }
 \description{
 Compares the current version of two scripts against one another.

--- a/man/diffPreviousRevisions.Rd
+++ b/man/diffPreviousRevisions.Rd
@@ -9,7 +9,8 @@ diffPreviousRevisions(
   .previous_revision,
   .current_revision = NULL,
   .side_by_side = TRUE,
-  .ignore_white_space = FALSE
+  .ignore_white_space = FALSE,
+  .display_entire_file = FALSE
 )
 }
 \arguments{
@@ -22,6 +23,8 @@ diffPreviousRevisions(
 \item{.side_by_side}{Logical. Should diffs be displayed side by side?}
 
 \item{.ignore_white_space}{Logical. Should white space be ignored?}
+
+\item{.display_entire_file}{Logical. Should the entire file be displayed?}
 }
 \description{
 Compares the current version of a script with a previous revision.

--- a/man/diffQced.Rd
+++ b/man/diffQced.Rd
@@ -4,7 +4,12 @@
 \alias{diffQced}
 \title{Visual diff of last QCed version of a file to the local version.}
 \usage{
-diffQced(.file, .side_by_side = TRUE, .ignore_white_space = FALSE)
+diffQced(
+  .file,
+  .side_by_side = TRUE,
+  .ignore_white_space = FALSE,
+  .display_entire_file = FALSE
+)
 }
 \arguments{
 \item{.file}{file path from working directory}
@@ -12,6 +17,8 @@ diffQced(.file, .side_by_side = TRUE, .ignore_white_space = FALSE)
 \item{.side_by_side}{Logical. Should diffs be displayed side by side?}
 
 \item{.ignore_white_space}{Logical. Should white space be ignored?}
+
+\item{.display_entire_file}{Logical. Should the entire file be displayed?}
 }
 \description{
 Compares the local version of a script with the most recent QCed version.

--- a/man/review-package.Rd
+++ b/man/review-package.Rd
@@ -12,6 +12,7 @@ Functions for managing logs of reviews of subversioned files (http://subversion.
 Useful links:
 \itemize{
   \item \url{https://github.com/metrumresearchgroup/review}
+  \item \url{https://metrumresearchgroup.github.io/review/}
   \item Report bugs at \url{https://github.com/metrumresearchgroup/review/issues}
 }
 


### PR DESCRIPTION
This PR allows the showing of the entire context of a file being diffed. Check out `?diffobj::diffFile` to see where the values come from.