### PR TITLE
Enhance renderQCReport(): Require .output_dir, add .project_number argument, and clarify report naming

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: review
 Title: QC Management and Helpers
-Version: 3.10.0.8003
+Version: 3.10.0.8004
 Authors@R: 
     c(
     person(given = "Eric", family = "Anderson", email = "andersone@metrumrg.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,17 @@
 
 - Fixed multiple log accept case in `getQcedRevision`. (#157)
 
+## New features and changes
+
+- `renderQCReport` now requires the .output_dir argument (previously optional).
+  A new optional .project_number argument has been added; if not supplied, the
+  project number is inferred from the SVN project URL. The output PDF filename
+  now uses a project-specific prefix: if .project_number is supplied, the entire
+  lowercased value is used; if inferred, the last element of the SVN project
+  name (after splitting by -) is used (lowercased). The project parameter within
+  the report is always set to the last part of the SVN project URL, regardless
+  of .project_number. Example: one-qc-report-YYYY-MM-DD.pdf. (#999)
+
 # review 3.10.0
 
 ## New features and changes

--- a/man/renderQCReport.Rd
+++ b/man/renderQCReport.Rd
@@ -4,15 +4,18 @@
 \alias{renderQCReport}
 \title{Render a QC Report Document}
 \usage{
-renderQCReport(.output_dir = NULL)
+renderQCReport(.output_dir, .project_number = NULL)
 }
 \arguments{
-\item{.output_dir}{Character string (optional). Path to the directory where the output PDF
-should be saved. If not provided, the document will not be saved locally.}
+\item{.output_dir}{Character string. Path to the directory where the output PDF
+should be saved. This argument is required.}
+
+\item{.project_number}{Character string (optional). Used for the output PDF filename
+prefix. If NULL (default), inferred from the SVN project URL.}
 }
 \value{
-Invisible. The function will save a PDF report named "qc-report-(current date).pdf"
-to the specified output directory (if available). If the R session is interactive, it will also
+Invisible. The function will save a PDF report named "\if{html}{\out{<project>}}-qc-report-(current date).pdf"
+to the specified output directory. If the R session is interactive, it will also
 open the PDF in the default browser.
 }
 \description{
@@ -24,7 +27,7 @@ The QC status of all files in the QC log will be displayed.
 }
 \examples{
 \dontrun{
-renderQCReport()
+renderQCReport("deliv/report")
 }
 
 }

--- a/review.Rproj
+++ b/review.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 58d0c27d-f73b-4ea2-af11-634e3a03c173
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/tests/testthat/test-renderQCReport.R
+++ b/tests/testthat/test-renderQCReport.R
@@ -5,12 +5,38 @@ if (Sys.getenv("METWORX_VERSION") != "") {
   logAssign("script/model-management.R")
   logAccept("script/box-sample-code.R")
   
-  test_that("renderQCReport works with valid directory", {
-    
+  test_that("renderQCReport errors if .output_dir is missing", {
+    expect_error(renderQCReport(), "'.output_dir' is required")
+  })
+  
+  test_that("renderQCReport works with valid directory and default project_number", {
     renderQCReport(.output_dir = logRoot())
-    
-    # Check that the output file was created
-    expect_true(file.exists(file.path(logRoot(), paste0("qc-report-", Sys.Date(), ".pdf"))))
-    
+    # project_number parameter inside the report comes from SVN URL (e.g., "review-tests")
+    # report_suffix (used in file name) is derived from the last part of the SVN URL (e.g., "tests")
+    expected_file <- file.path(logRoot(), paste0("tests-qc-report-", Sys.Date(), ".pdf"))
+    expect_true(file.exists(expected_file))
+  })
+  
+  test_that("renderQCReport works with explicit project_number", {
+    renderQCReport(.output_dir = logRoot(), .project_number = "abc-study-ONE")
+    # PDF file uses provided .project_number (lowercased)
+    # project parameter in report still comes from SVN
+    expected_file <- file.path(logRoot(), paste0(tolower("abc-study-ONE"), "-qc-report-", Sys.Date(), ".pdf"))
+    expect_true(file.exists(expected_file))
+  })
+  
+  test_that("renderQCReport errors if directory does not exist", {
+    expect_error(
+      renderQCReport(.output_dir = tempfile()),
+      "does not exist"
+    )
+  })
+  
+  test_that("renderQCReport works with project_number with no dash", {
+    renderQCReport(.output_dir = logRoot(), .project_number = "SINGLE")
+    # PDF file uses provided .project_number (lowercased)
+    # project parameter in report still comes from SVN
+    expected_file <- file.path(logRoot(), paste0("single-qc-report-", Sys.Date(), ".pdf"))
+    expect_true(file.exists(expected_file))
   })
 }


### PR DESCRIPTION
## Summary

This PR updates the `renderQCReport()` function with improved argument handling and report generation logic:

- `.output_dir` is now a required argument (previously optional).
- New optional `.project_number` argument controls the output PDF filename prefix. If not supplied, the prefix is inferred from the SVN project URL.
- The PDF file name now uses a project-specific prefix (from `.project_number` or inferred from SVN, both lowercased).
- The `project` parameter *inside* the report is always set to the last segment of the SVN project URL, regardless of `.project_number`.
- Updated documentation, examples, and tests to reflect new behavior.
- Added or improved error handling and code comments for clarity.

**Example filename:**  
`one-qc-report-YYYY-MM-DD.pdf`