### PR TITLE
Trim whitespace in svnLog

### DIFF
--- a/R/svnLog.R
+++ b/R/svnLog.R
@@ -25,7 +25,8 @@ svnLog <- function(.file) {
   log_return <- 
     dplyr::bind_rows(log_df) %>% 
     dplyr::rename(rev = .attrs) %>% 
-    dplyr::mutate(datetime = as.POSIXct(date, format="%Y-%m-%dT%H:%M:%OS", tz="UTC")) %>% 
+    dplyr::mutate(datetime = as.POSIXct(date, format="%Y-%m-%dT%H:%M:%OS", tz="UTC"),
+                  msg = trimws(msg)) %>% 
     dplyr::select(author, datetime, rev, msg)
   
   log_return

--- a/tests/testthat/test-svnLog.R
+++ b/tests/testthat/test-svnLog.R
@@ -17,5 +17,12 @@ with_demoRepo({
     expect_equal(as.numeric(logFile1$rev[1]), 5)
     expect_equal(as.numeric(logFile2$rev[1]), 4)
   })
+  
+  test_that("svnLog trims whitespace from commit messages", {
+    cat("# whitespace msg\n", file = file1, append = TRUE)
+    system("svn commit -m '  spaced commit message  ' -q -q")
+    
+    trimmed_log <- svnLog(file1)
+    expect_equal(trimmed_log$msg[1], "spaced commit message")
+  })
 })
-


### PR DESCRIPTION
  ## Summary
  - trim leading and trailing whitespace from svnLog messages
  Addresses #177 