### PR TITLE
fileSummary support directory inputs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,8 @@ Suggests:
     knitr,
     testthat (>= 3.0.0),
     readr,
-    withr (>= 2.5.0)
+    withr (>= 2.5.0),
+    purrr
 Config/testthat/edition: 3
 VignetteBuilder: 
     knitr

--- a/R/fileSummary.R
+++ b/R/fileSummary.R
@@ -51,7 +51,7 @@ fileSummary <- function(.file) {
       return(invisible(list()))
     }
 
-    out <- lapply(files, fileSummary)
+    out <- lapply(files, fileSummary_one)
     names(out) <- files
 
     return(invisible(out))
@@ -168,4 +168,9 @@ fileSummary <- function(.file) {
   cli::cli_bullets(out$authors)
   
   return(invisible(out))
+}
+
+# Internal helper for per-file summaries.
+fileSummary_one <- function(.file) {
+  fileSummary(.file = .file)
 }

--- a/R/fileSummary.R
+++ b/R/fileSummary.R
@@ -170,7 +170,8 @@ fileSummary <- function(.file) {
   return(invisible(out))
 }
 
-# Internal helper for per-file summaries.
+#' Internal helper for per-file summaries.
+#' @noRd
 fileSummary_one <- function(.file) {
   fileSummary(.file = .file)
 }

--- a/R/fileSummary.R
+++ b/R/fileSummary.R
@@ -1,4 +1,4 @@
-#' Summarize revision and QC history for a file
+#' Summarize revision and QC history for a file or directory
 #'
 #' @description
 #' Generates a comprehensive summary of the revision and quality control (QC) history
@@ -8,12 +8,14 @@
 #' * Historical information about previous authors
 #' * Historical information about previous QC reviewers
 #'
-#' @param .file File path.
+#' @param .file File or directory path.
 #'
 #' @details
 #' The function prints a formatted summary to the console and invisibly returns
-#' the data for programmatic use. Non-existent files generate warnings and are
-#' skipped. Files not found in the repository history are also skipped.
+#' the data for programmatic use. If a directory is supplied, each immediate
+#' file in that directory is summarized and a named list of results is returned.
+#' Non-existent files generate warnings and are skipped. Files not found in the
+#' repository history are also skipped.
 #'
 #' QC status can be:
 #' * "QC up to date" - Latest revision has been QC'd
@@ -26,18 +28,33 @@
 #' fileSummary("script/data-assembly/study-101.R")
 #'
 #' # Process all files in a directory
-#' purrr::walk(list.files("script/data-assembly", full.names = TRUE), ~ fileSummary(.file = .x))
+#' fileSummary("script/data-assembly")
 #' }
 #'
 #' @export
 fileSummary <- function(.file) {
   if (length(.file) != 1) {
-    stop("'.file' must be a single file path")
+    stop("'.file' must be a single file or directory path")
   }
   
   if (!file.exists(.file)) {
     warning(paste0(.file, " does not exist"))
     return(invisible(NULL))
+  }
+
+  if (fs::is_dir(.file)) {
+    files <- list.files(.file, full.names = TRUE)
+    files <- files[!fs::is_dir(files)]
+
+    if (length(files) == 0) {
+      warning(paste0(.file, " contains no files"))
+      return(invisible(list()))
+    }
+
+    out <- lapply(files, fileSummary)
+    names(out) <- files
+
+    return(invisible(out))
   }
   
   log_df <- tryCatch(

--- a/man/fileSummary.Rd
+++ b/man/fileSummary.Rd
@@ -2,12 +2,12 @@
 % Please edit documentation in R/fileSummary.R
 \name{fileSummary}
 \alias{fileSummary}
-\title{Summarize revision and QC history for a file}
+\title{Summarize revision and QC history for a file or directory}
 \usage{
 fileSummary(.file)
 }
 \arguments{
-\item{.file}{File path.}
+\item{.file}{File or directory path.}
 }
 \description{
 Generates a comprehensive summary of the revision and quality control (QC) history
@@ -21,8 +21,10 @@ for a file. The function reports:
 }
 \details{
 The function prints a formatted summary to the console and invisibly returns
-the data for programmatic use. Non-existent files generate warnings and are
-skipped. Files not found in the repository history are also skipped.
+the data for programmatic use. If a directory is supplied, each immediate
+file in that directory is summarized and a named list of results is returned.
+Non-existent files generate warnings and are skipped. Files not found in the
+repository history are also skipped.
 
 QC status can be:
 \itemize{
@@ -37,7 +39,7 @@ QC status can be:
 fileSummary("script/data-assembly/study-101.R")
 
 # Process all files in a directory
-purrr::walk(list.files("script/data-assembly", full.names = TRUE), ~ fileSummary(.file = .x))
+fileSummary("script/data-assembly")
 }
 
 }

--- a/tests/testthat/test-fileSummary.R
+++ b/tests/testthat/test-fileSummary.R
@@ -2,9 +2,22 @@ create_test_svn()
 logAccept("script/data-assembly/da-functions.R")
 logAssign("script/model-summary.Rmd")
 
-test_that("Function requires single file input", {
+test_that("Function requires single file or directory input", {
+  da_files <- c(
+    "script/data-assembly/da-functions.R",
+    "script/data-assembly/da-study-abc.Rmd"
+  )
+  expect_error(fileSummary(da_files), "must be a single file or directory path")
+})
+
+test_that("Works correctly for a directory input", {
+  da_directory <- fileSummary("script/data-assembly")
   da_files <- list.files("script/data-assembly", full.names = TRUE)
-  expect_error(fileSummary(da_files), "must be a single file path")
+  da_files <- da_files[!fs::is_dir(da_files)]
+
+  expect_true(is.list(da_directory))
+  expect_setequal(names(da_directory), da_files)
+  expect_true(all(vapply(da_directory, is.list, logical(1))))
 })
 
 test_that("Works correctly for a single file QC filed", {

--- a/tests/testthat/test-fileSummary.R
+++ b/tests/testthat/test-fileSummary.R
@@ -20,6 +20,28 @@ test_that("Works correctly for a directory input", {
   expect_true(all(vapply(da_directory, is.list, logical(1))))
 })
 
+test_that("Directory input matches purrr::walk-based file summaries", {
+  testthat::skip_if_not_installed("purrr")
+
+  da_files <- list.files("script/data-assembly", full.names = TRUE)
+  da_files <- da_files[!fs::is_dir(da_files)]
+
+  from_directory <- fileSummary("script/data-assembly")
+
+  from_walk <- list()
+  purrr::walk(
+    da_files,
+    ~ {
+      from_walk[[.x]] <<- fileSummary(.file = .x)
+    }
+  )
+
+  from_directory <- from_directory[order(names(from_directory))]
+  from_walk <- from_walk[order(names(from_walk))]
+
+  expect_equal(from_directory, from_walk)
+})
+
 test_that("Works correctly for a single file QC filed", {
   da_functions <- fileSummary("script/data-assembly/da-functions.R")
   


### PR DESCRIPTION
## Summary

  This PR updates fileSummary() so it can accept either a single file path or a directory path.

  ## What Changed

  - Added directory handling in fileSummary() using fs::is_dir().
  - When a directory is supplied, fileSummary() now:
      - Lists immediate files in that directory.
      - Excludes subdirectories.
      - Runs fileSummary() on each file.
      - Invisibly returns a named list of per-file summaries.
  - Kept existing single-file behavior intact.
  - Updated error text to reflect the new input contract (single file or directory path).
  - Updated documentation (R/fileSummary.R, man/fileSummary.Rd) including examples.
  - Added tests for directory input and updated existing input-validation expectations.

  ## Why

  This removes the need for external loops like:
  purrr::walk(list.files(...), ~ review::fileSummary(.file = .x))
  and makes directory-level summaries a built-in behavior of fileSummary().
