### PR TITLE
Add quick diff actions to diffDashboard

### DIFF
--- a/R/diffDashboard.R
+++ b/R/diffDashboard.R
@@ -110,6 +110,11 @@ diffDashboard <- function(.file) {
       current <- selection()
 
       base_style <- "width:100%; white-space:normal;"
+      disabled_style <- paste0(
+        base_style,
+        " background-color:#f3f4f6; border-color:#d1d5db; color:#9ca3af;",
+        " box-shadow:none; font-weight:400; cursor:not-allowed;"
+      )
       active_style <- paste0(
         base_style,
         " background-color:#eef4ff; border-color:#9bbcff; color:#1f4fa3;",
@@ -123,30 +128,23 @@ diffDashboard <- function(.file) {
           current$prior == latest_revision
       )
 
+      qc_active <- FALSE
       if (!is.na(qced_revision)) {
         qc_active <- isTRUE(
           !is.null(current$prior) &&
             is.null(current$newer) &&
             current$prior == qced_revision
         )
-
-        return(shiny::div(
-          style = "display:grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap:8px; margin-bottom:12px;",
-          shiny::actionButton(
-            "jump_qc_local",
-            "Last QC -> Local",
-            style = if (qc_active) active_style else base_style
-          ),
-          shiny::actionButton(
-            "jump_latest_local",
-            "Latest SVN -> Local",
-            style = if (latest_active) active_style else base_style
-          )
-        ))
       }
 
       shiny::div(
-        style = "display:flex; margin-bottom:12px;",
+        style = "display:grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap:8px; margin-bottom:12px;",
+        shiny::actionButton(
+          "jump_qc_local",
+          "Last QC -> Local",
+          style = if (is.na(qced_revision)) disabled_style else if (qc_active) active_style else base_style,
+          disabled = if (is.na(qced_revision)) "disabled" else NULL
+        ),
         shiny::actionButton(
           "jump_latest_local",
           "Latest SVN -> Local",

--- a/R/diffDashboard.R
+++ b/R/diffDashboard.R
@@ -121,7 +121,7 @@ diffDashboard <- function(.file) {
       active_style <- paste0(
         base_style,
         " border-color:#8fb4ff;",
-        " box-shadow:0 0 0 4px rgba(44,123,229,0.22), inset 0 0 0 1px rgba(143,180,255,0.55);",
+        " box-shadow:0 0 0 6px rgba(44,123,229,0.20), inset 0 0 0 1px rgba(143,180,255,0.55);",
         " font-weight:600;"
       )
 
@@ -142,10 +142,10 @@ diffDashboard <- function(.file) {
       }
 
       shiny::div(
-        style = "margin-top:-10px; margin-bottom:12px;",
+        style = "margin-top:-18px; margin-bottom:12px;",
         shiny::div(
           class = "text-muted",
-          style = "font-size:0.8rem; text-transform:uppercase; letter-spacing:0.04em; margin-bottom:4px;",
+          style = "font-size:0.8rem; text-transform:uppercase; letter-spacing:0.04em; margin-bottom:2px;",
           "Quick actions"
         )
       ,

--- a/R/diffDashboard.R
+++ b/R/diffDashboard.R
@@ -121,7 +121,7 @@ diffDashboard <- function(.file) {
       active_style <- paste0(
         base_style,
         " border-color:#8fb4ff;",
-        " box-shadow:0 0 0 2px rgba(44,123,229,0.28), inset 0 0 0 1px rgba(143,180,255,0.55);",
+        " box-shadow:0 0 0 4px rgba(44,123,229,0.22), inset 0 0 0 1px rgba(143,180,255,0.55);",
         " font-weight:600;"
       )
 
@@ -142,10 +142,10 @@ diffDashboard <- function(.file) {
       }
 
       shiny::div(
-        style = "margin-top:-2px; margin-bottom:12px;",
+        style = "margin-top:-10px; margin-bottom:12px;",
         shiny::div(
           class = "text-muted",
-          style = "font-size:0.8rem; text-transform:uppercase; letter-spacing:0.04em; margin-bottom:6px;",
+          style = "font-size:0.8rem; text-transform:uppercase; letter-spacing:0.04em; margin-bottom:4px;",
           "Quick actions"
         )
       ,

--- a/R/diffDashboard.R
+++ b/R/diffDashboard.R
@@ -33,7 +33,8 @@ diffDashboard <- function(.file) {
       # minimal styles and a simple click handler
       timeline_assets("calc(100vh - 160px)"),
       shiny::div(
-        class = "text-muted mb-2",
+        class = "text-muted",
+        style = "margin-top:-8px; margin-bottom:0;",
         shiny::tags$i(
           "Click two to compare. Older is red, newer is green.",
           style = "font-size: smaller;"
@@ -142,7 +143,7 @@ diffDashboard <- function(.file) {
       }
 
       shiny::div(
-        style = "margin-top:-18px; margin-bottom:12px;",
+        style = "margin-top:-24px; margin-bottom:12px;",
         shiny::div(
           class = "text-muted",
           style = "font-size:0.8rem; text-transform:uppercase; letter-spacing:0.04em; margin-bottom:2px;",

--- a/R/diffDashboard.R
+++ b/R/diffDashboard.R
@@ -121,7 +121,7 @@ diffDashboard <- function(.file) {
       active_style <- paste0(
         base_style,
         " border-color:#8fb4ff;",
-        " box-shadow:0 0 0 6px rgba(44,123,229,0.20), inset 0 0 0 1px rgba(143,180,255,0.55);",
+        " box-shadow:0 0 0 5px rgba(44,123,229,0.20), inset 0 0 0 1px rgba(143,180,255,0.55);",
         " font-weight:600;"
       )
 

--- a/R/diffDashboard.R
+++ b/R/diffDashboard.R
@@ -109,7 +109,10 @@ diffDashboard <- function(.file) {
     output$quick_actions <- shiny::renderUI({
       current <- selection()
 
-      base_style <- "width:100%; white-space:normal;"
+      base_style <- paste0(
+        "width:100%; white-space:normal;",
+        " background-color:#3f4348; border-color:#3f4348; color:#ffffff;"
+      )
       disabled_style <- paste0(
         base_style,
         " background-color:#f3f4f6; border-color:#d1d5db; color:#9ca3af;",
@@ -117,8 +120,9 @@ diffDashboard <- function(.file) {
       )
       active_style <- paste0(
         base_style,
-        " background-color:#f8fbff; border-color:#8fb4ff; color:#1f4fa3;",
-        " box-shadow:inset 0 0 0 1px rgba(44,123,229,0.24); font-weight:600;"
+        " border-color:#8fb4ff;",
+        " box-shadow:0 0 0 2px rgba(44,123,229,0.28), inset 0 0 0 1px rgba(143,180,255,0.55);",
+        " font-weight:600;"
       )
 
       latest_active <- isTRUE(
@@ -138,7 +142,7 @@ diffDashboard <- function(.file) {
       }
 
       shiny::div(
-        style = "margin-bottom:12px;",
+        style = "margin-top:-2px; margin-bottom:12px;",
         shiny::div(
           class = "text-muted",
           style = "font-size:0.8rem; text-transform:uppercase; letter-spacing:0.04em; margin-bottom:6px;",

--- a/R/diffDashboard.R
+++ b/R/diffDashboard.R
@@ -18,6 +18,8 @@
 diffDashboard <- function(.file) {
   # --- Data prep ---
   svn_log <- getRevHistory(.file = .file)
+  qced_revision <- getQcedRevision(.file)
+  latest_revision <- max(as.numeric(svn_log$rev[svn_log$rev != "Local"]), na.rm = TRUE)
 
   default_sel <- default_selection_from_log(svn_log)
 
@@ -37,6 +39,7 @@ diffDashboard <- function(.file) {
           style = "font-size: smaller;"
         )
       ),
+      shiny::uiOutput("quick_actions"),
       shiny::div(class = "side-scroll", shiny::uiOutput("timeline_ui"))
     ),
 
@@ -86,6 +89,71 @@ diffDashboard <- function(.file) {
       },
       ignoreInit = TRUE
     )
+
+    shiny::observeEvent(
+      input$jump_qc_local,
+      {
+        selection(compute_selection(c(as.character(qced_revision), "Local")))
+      },
+      ignoreInit = TRUE
+    )
+
+    shiny::observeEvent(
+      input$jump_latest_local,
+      {
+        selection(compute_selection(default_sel))
+      },
+      ignoreInit = TRUE
+    )
+
+    output$quick_actions <- shiny::renderUI({
+      current <- selection()
+
+      base_style <- "width:100%; white-space:normal;"
+      active_style <- paste0(
+        base_style,
+        " background-color:#eef4ff; border-color:#9bbcff; color:#1f4fa3;",
+        " box-shadow:0 0 0 2px rgba(44,123,229,0.16); font-weight:600;"
+      )
+
+      latest_active <- isTRUE(
+        !is.null(current$prior) &&
+          is.null(current$newer) &&
+          !is.na(latest_revision) &&
+          current$prior == latest_revision
+      )
+
+      if (!is.na(qced_revision)) {
+        qc_active <- isTRUE(
+          !is.null(current$prior) &&
+            is.null(current$newer) &&
+            current$prior == qced_revision
+        )
+
+        return(shiny::div(
+          style = "display:grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap:8px; margin-bottom:12px;",
+          shiny::actionButton(
+            "jump_qc_local",
+            "Last QC -> Local",
+            style = if (qc_active) active_style else base_style
+          ),
+          shiny::actionButton(
+            "jump_latest_local",
+            "Latest SVN -> Local",
+            style = if (latest_active) active_style else base_style
+          )
+        ))
+      }
+
+      shiny::div(
+        style = "display:flex; margin-bottom:12px;",
+        shiny::actionButton(
+          "jump_latest_local",
+          "Latest SVN -> Local",
+          style = if (latest_active) active_style else base_style
+        )
+      )
+    })
 
     # --- Timeline UI (LOCAL first, then SVN revisions) ---
     output$timeline_ui <- shiny::renderUI({

--- a/R/diffDashboard.R
+++ b/R/diffDashboard.R
@@ -117,8 +117,8 @@ diffDashboard <- function(.file) {
       )
       active_style <- paste0(
         base_style,
-        " background-color:#eef4ff; border-color:#9bbcff; color:#1f4fa3;",
-        " box-shadow:0 0 0 2px rgba(44,123,229,0.16); font-weight:600;"
+        " background-color:#f8fbff; border-color:#8fb4ff; color:#1f4fa3;",
+        " box-shadow:inset 0 0 0 1px rgba(44,123,229,0.24); font-weight:600;"
       )
 
       latest_active <- isTRUE(
@@ -138,17 +138,26 @@ diffDashboard <- function(.file) {
       }
 
       shiny::div(
-        style = "display:grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap:8px; margin-bottom:12px;",
-        shiny::actionButton(
-          "jump_qc_local",
-          "Last QC -> Local",
-          style = if (is.na(qced_revision)) disabled_style else if (qc_active) active_style else base_style,
-          disabled = if (is.na(qced_revision)) "disabled" else NULL
-        ),
-        shiny::actionButton(
-          "jump_latest_local",
-          "Latest SVN -> Local",
-          style = if (latest_active) active_style else base_style
+        style = "margin-bottom:12px;",
+        shiny::div(
+          class = "text-muted",
+          style = "font-size:0.8rem; text-transform:uppercase; letter-spacing:0.04em; margin-bottom:6px;",
+          "Quick actions"
+        )
+      ,
+        shiny::div(
+          style = "display:grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap:8px;",
+          shiny::actionButton(
+            "jump_qc_local",
+            "Last QC -> Local",
+            style = if (is.na(qced_revision)) disabled_style else if (qc_active) active_style else base_style,
+            disabled = if (is.na(qced_revision)) "disabled" else NULL
+          ),
+          shiny::actionButton(
+            "jump_latest_local",
+            "Latest SVN -> Local",
+            style = if (latest_active) active_style else base_style
+          )
         )
       )
     })

--- a/R/diffDashboard.R
+++ b/R/diffDashboard.R
@@ -34,7 +34,7 @@ diffDashboard <- function(.file) {
       timeline_assets("calc(100vh - 160px)"),
       shiny::div(
         class = "text-muted",
-        style = "margin-top:-8px; margin-bottom:0;",
+        style = "margin-top:-8px; margin-bottom:8px;",
         shiny::tags$i(
           "Click two to compare. Older is red, newer is green.",
           style = "font-size: smaller;"
@@ -122,7 +122,7 @@ diffDashboard <- function(.file) {
       active_style <- paste0(
         base_style,
         " border-color:#8fb4ff;",
-        " box-shadow:0 0 0 5px rgba(44,123,229,0.20), inset 0 0 0 1px rgba(143,180,255,0.55);",
+        " box-shadow:0 0 0 4px rgba(44,123,229,0.20), inset 0 0 0 1px rgba(143,180,255,0.55);",
         " font-weight:600;"
       )
 
@@ -143,7 +143,7 @@ diffDashboard <- function(.file) {
       }
 
       shiny::div(
-        style = "margin-top:-24px; margin-bottom:12px;",
+        style = "margin-top:-18px; margin-bottom:12px;",
         shiny::div(
           class = "text-muted",
           style = "font-size:0.8rem; text-transform:uppercase; letter-spacing:0.04em; margin-bottom:2px;",


### PR DESCRIPTION
Adds quick reset actions to diffDashboard() for the two most common comparisons: `Last QC -> Local` and `Latest SVN -> Local`.

The new buttons reuse the existing selection state in the dashboard rather than introducing a separate diff path, so manual timeline selection and button-driven selection stay in sync. `Last QC -> Local` is shown but disabled when a file has never been QCed.
