### PR TITLE
Add directory summary feature to fileSummary

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: review
 Title: QC Management and Helpers
-Version: 3.14.0
+Version: 3.14.0.9000
 Authors@R: 
     c(
     person(given = "Eric", family = "Anderson", email = "andersone@metrumrg.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# review development
+
+## New features and changes
+
+- Added argument to return summary table to `fileSummary` when given a directory. 
+
 # review 3.14.0
 
 ## New features and changes

--- a/R/fileSummary.R
+++ b/R/fileSummary.R
@@ -9,7 +9,7 @@
 #' * Historical information about previous QC reviewers
 #'
 #' @param .file File or directory path.
-#' @param .return_dir_table Set to TRUE to print a table summarizing QC status of all files in a directory. Defaults to FALSE.
+#' @param .return_df Set to TRUE to print a table summarizing QC status of all files in a directory. Defaults to FALSE.
 #'
 #' @details
 #' The function prints a formatted summary to the console and invisibly returns
@@ -29,11 +29,11 @@
 #' fileSummary("script/data-assembly/study-101.R")
 #'
 #' # Process all files in a directory
-#' fileSummary("script/data-assembly", .return_dir_table = TRUE)
+#' fileSummary("script/data-assembly", .return_df = TRUE)
 #' }
 #'
 #' @export
-fileSummary <- function(.file, .return_dir_table = FALSE) {
+fileSummary <- function(.file, .return_df = FALSE) {
   if (length(.file) != 1) {
     stop("'.file' must be a single file or directory path")
   }
@@ -55,7 +55,7 @@ fileSummary <- function(.file, .return_dir_table = FALSE) {
     out <- lapply(files, fileSummary_one)
     names(out) <- files
     
-    if (.return_dir_table) {
+    if (.return_df) {
       
       cli::cli_h2(glue::glue(.file, " directory summary"))
       

--- a/R/fileSummary.R
+++ b/R/fileSummary.R
@@ -9,6 +9,7 @@
 #' * Historical information about previous QC reviewers
 #'
 #' @param .file File or directory path.
+#' @param .return_dir_table Set to TRUE to print a table summarizing QC status of all files in a directory. Defaults to FALSE.
 #'
 #' @details
 #' The function prints a formatted summary to the console and invisibly returns
@@ -28,11 +29,11 @@
 #' fileSummary("script/data-assembly/study-101.R")
 #'
 #' # Process all files in a directory
-#' fileSummary("script/data-assembly")
+#' fileSummary("script/data-assembly", .return_dir_table = TRUE)
 #' }
 #'
 #' @export
-fileSummary <- function(.file) {
+fileSummary <- function(.file, .return_dir_table = FALSE) {
   if (length(.file) != 1) {
     stop("'.file' must be a single file or directory path")
   }
@@ -53,6 +54,23 @@ fileSummary <- function(.file) {
 
     out <- lapply(files, fileSummary_one)
     names(out) <- files
+    
+    if (.return_dir_table) {
+      
+      cli::cli_h2(glue::glue(.file, " directory summary"))
+      
+      return(
+        do.call(rbind, lapply(out, function(x) {
+          data.frame(
+            QCLOG    = as.character(x$qclog),
+            QCSTATUS = as.character(x$qcstatus),
+            stringsAsFactors = FALSE
+          )
+        })) %>% 
+          dplyr::mutate(dplyr::across(dplyr::everything(), cli::ansi_strip)) %>% 
+          dplyr::rename(`In QC Log` = QCLOG, `QC Status` = QCSTATUS)
+      )
+    }
 
     return(invisible(out))
   }

--- a/R/reviewPackage.R
+++ b/R/reviewPackage.R
@@ -29,6 +29,7 @@ globalVariables(
     "path",
     "page",
     "type",
-    "code_path"
+    "code_path",
+    "QCLOG"
   )
 )

--- a/man/fileSummary.Rd
+++ b/man/fileSummary.Rd
@@ -4,12 +4,12 @@
 \alias{fileSummary}
 \title{Summarize revision and QC history for a file or directory}
 \usage{
-fileSummary(.file, .return_dir_table = FALSE)
+fileSummary(.file, .return_df = FALSE)
 }
 \arguments{
 \item{.file}{File or directory path.}
 
-\item{.return_dir_table}{Set to TRUE to print a table summarizing QC status of all files in a directory. Defaults to FALSE.}
+\item{.return_df}{Set to TRUE to print a table summarizing QC status of all files in a directory. Defaults to FALSE.}
 }
 \description{
 Generates a comprehensive summary of the revision and quality control (QC) history
@@ -41,7 +41,7 @@ QC status can be:
 fileSummary("script/data-assembly/study-101.R")
 
 # Process all files in a directory
-fileSummary("script/data-assembly", .return_dir_table = TRUE)
+fileSummary("script/data-assembly", .return_df = TRUE)
 }
 
 }

--- a/man/fileSummary.Rd
+++ b/man/fileSummary.Rd
@@ -4,10 +4,12 @@
 \alias{fileSummary}
 \title{Summarize revision and QC history for a file or directory}
 \usage{
-fileSummary(.file)
+fileSummary(.file, .return_dir_table = FALSE)
 }
 \arguments{
 \item{.file}{File or directory path.}
+
+\item{.return_dir_table}{Set to TRUE to print a table summarizing QC status of all files in a directory. Defaults to FALSE.}
 }
 \description{
 Generates a comprehensive summary of the revision and quality control (QC) history
@@ -39,7 +41,7 @@ QC status can be:
 fileSummary("script/data-assembly/study-101.R")
 
 # Process all files in a directory
-fileSummary("script/data-assembly")
+fileSummary("script/data-assembly", .return_dir_table = TRUE)
 }
 
 }

--- a/tests/testthat/test-fileSummary.R
+++ b/tests/testthat/test-fileSummary.R
@@ -66,9 +66,9 @@ test_that("Function handles non-existent files appropriately", {
   expect_null(non_nonexistent)
 })
 
-test_that("Function prints data.frame when .return_dir_table argument set to TRUE", {
-  x1 <- fileSummary(.file = "script", .return_dir_table = F) %>% suppressMessages()
-  x2 <- fileSummary(.file = "script", .return_dir_table = T) %>% suppressMessages()
+test_that("Function prints data.frame when .return_df argument set to TRUE", {
+  x1 <- fileSummary(.file = "script", .return_df = F) %>% suppressMessages()
+  x2 <- fileSummary(.file = "script", .return_df = T) %>% suppressMessages()
   
   expect_true(inherits(x2, "data.frame"))
   expect_true(length(x2) == 2)

--- a/tests/testthat/test-fileSummary.R
+++ b/tests/testthat/test-fileSummary.R
@@ -65,3 +65,12 @@ test_that("Function handles non-existent files appropriately", {
   )
   expect_null(non_nonexistent)
 })
+
+test_that("Function prints data.frame when .return_dir_table argument set to TRUE", {
+  x1 <- fileSummary(.file = "script", .return_dir_table = F) %>% suppressMessages()
+  x2 <- fileSummary(.file = "script", .return_dir_table = T) %>% suppressMessages()
+  
+  expect_true(inherits(x2, "data.frame"))
+  expect_true(length(x2) == 2)
+  expect_equal(nrow(x2), length(x1))
+})


### PR DESCRIPTION
For cases with lots of files in a directory, users may find it easier to review a summary table instead of scrolling through the console. This implementation provides a summary table at the end giving a high level overview of the QC status. The individual files are still printed to allow users to investigate any unexpected findings after reviewing the summary table
<img width="373" height="312" alt="Screenshot 2026-04-20 at 2 34 56 PM" src="https://github.com/user-attachments/assets/8cb0e366-3115-490b-b0f7-2b1887acd6a3" />
