### PR TITLE
Improve revision selection UX in diffDashboard

### DIFF
--- a/R/compareDashboard.R
+++ b/R/compareDashboard.R
@@ -128,12 +128,7 @@ compareDashboard <- function(.path) {
         cur <- selection()
         clicked <- as.character(input$rev_clicked)
         new_ids <- if (length(cur$ids) >= 2L && !clicked %in% cur$ids) {
-          prior_id <- if (!is.null(cur$prior)) {
-            as.character(cur$prior)
-          } else {
-            cur$ids[1L]
-          }
-          c(setdiff(cur$ids, prior_id), clicked)
+          resolve_third_click(cur$ids, clicked, svn_log())
         } else {
           update_selection(cur$ids, clicked, max_sel = 2L)
         }

--- a/R/compareDashboard.R
+++ b/R/compareDashboard.R
@@ -127,11 +127,7 @@ compareDashboard <- function(.path) {
       {
         cur <- selection()
         clicked <- as.character(input$rev_clicked)
-        new_ids <- if (length(cur$ids) >= 2L && !clicked %in% cur$ids) {
-          resolve_third_click(cur$ids, clicked, svn_log())
-        } else {
-          update_selection(cur$ids, clicked, max_sel = 2L)
-        }
+        new_ids <- update_selection(cur$ids, clicked, max_sel = 2L)
         selection(compute_selection(new_ids))
       },
       ignoreInit = TRUE

--- a/R/compareDashboard.R
+++ b/R/compareDashboard.R
@@ -35,6 +35,47 @@ compareDashboard <- function(.path) {
   fig_names <- basename(fig_files)
   fig_map <- stats::setNames(fig_files, fig_names)
 
+  modified <- tryCatch(
+    {
+      status <- svnCommand("status", .file = fs::path_abs(.path))
+      entries <- if (is.list(status$target)) {
+        status$target
+      } else {
+        list(status$target)
+      }
+      paths <- vapply(
+        entries,
+        function(e) {
+          if (is.list(e) && !is.null(e$.attrs[["path"]])) {
+            basename(e$.attrs[["path"]])
+          } else {
+            NA_character_
+          }
+        },
+        character(1L)
+      )
+      items <- vapply(
+        entries,
+        function(e) {
+          if (is.list(e) && !is.null(e[["wc-status"]])) {
+            e[["wc-status"]][[".attrs"]][["item"]]
+          } else {
+            NA_character_
+          }
+        },
+        character(1L)
+      )
+      paths[!is.na(paths) & !is.na(items) & items == "modified"]
+    },
+    error = function(e) character()
+  )
+
+  fig_labels <- ifelse(
+    fig_names %in% modified,
+    paste0(fig_names, " (M)"),
+    fig_names
+  )
+
   fig_dir <- fs::path_abs(.path)
   rev_dir <- file.path(tempdir(), "review-figure-dashboard")
   dir.create(rev_dir, showWarnings = FALSE, recursive = TRUE)
@@ -69,7 +110,11 @@ compareDashboard <- function(.path) {
         .fig-asset { width:100%; border:1px solid #e9ecef; }
         "
       ),
-      shiny::selectInput("figure_file", "Figure", choices = fig_names),
+      shiny::selectInput(
+        "figure_file",
+        "Figure",
+        choices = stats::setNames(fig_names, fig_labels)
+      ),
       shiny::div(
         class = "text-muted mb-2",
         shiny::tags$i(

--- a/R/compareDashboard.R
+++ b/R/compareDashboard.R
@@ -35,47 +35,6 @@ compareDashboard <- function(.path) {
   fig_names <- basename(fig_files)
   fig_map <- stats::setNames(fig_files, fig_names)
 
-  modified <- tryCatch(
-    {
-      status <- svnCommand("status", .file = fs::path_abs(.path))
-      entries <- if (is.list(status$target)) {
-        status$target
-      } else {
-        list(status$target)
-      }
-      paths <- vapply(
-        entries,
-        function(e) {
-          if (is.list(e) && !is.null(e$.attrs[["path"]])) {
-            basename(e$.attrs[["path"]])
-          } else {
-            NA_character_
-          }
-        },
-        character(1L)
-      )
-      items <- vapply(
-        entries,
-        function(e) {
-          if (is.list(e) && !is.null(e[["wc-status"]])) {
-            e[["wc-status"]][[".attrs"]][["item"]]
-          } else {
-            NA_character_
-          }
-        },
-        character(1L)
-      )
-      paths[!is.na(paths) & !is.na(items) & items == "modified"]
-    },
-    error = function(e) character()
-  )
-
-  fig_labels <- ifelse(
-    fig_names %in% modified,
-    paste0(fig_names, " (M)"),
-    fig_names
-  )
-
   fig_dir <- fs::path_abs(.path)
   rev_dir <- file.path(tempdir(), "review-figure-dashboard")
   dir.create(rev_dir, showWarnings = FALSE, recursive = TRUE)
@@ -110,11 +69,7 @@ compareDashboard <- function(.path) {
         .fig-asset { width:100%; border:1px solid #e9ecef; }
         "
       ),
-      shiny::selectInput(
-        "figure_file",
-        "Figure",
-        choices = stats::setNames(fig_names, fig_labels)
-      ),
+      shiny::selectInput("figure_file", "Figure", choices = fig_names),
       shiny::div(
         class = "text-muted mb-2",
         shiny::tags$i(

--- a/R/compareDashboard.R
+++ b/R/compareDashboard.R
@@ -35,6 +35,10 @@ compareDashboard <- function(.path) {
   fig_names <- basename(fig_files)
   fig_map <- stats::setNames(fig_files, fig_names)
 
+  sv_status <- svnStatus(fs::path_abs(.path))
+  modified <- sv_status$path[sv_status$status == "modified"]
+  fig_labels <- ifelse(fig_names %in% modified, paste0(fig_names, " (M)"), fig_names)
+
   fig_dir <- fs::path_abs(.path)
   rev_dir <- file.path(tempdir(), "review-figure-dashboard")
   dir.create(rev_dir, showWarnings = FALSE, recursive = TRUE)
@@ -69,7 +73,7 @@ compareDashboard <- function(.path) {
         .fig-asset { width:100%; border:1px solid #e9ecef; }
         "
       ),
-      shiny::selectInput("figure_file", "Figure", choices = fig_names),
+      shiny::selectInput("figure_file", "Figure", choices = stats::setNames(fig_names, fig_labels)),
       shiny::div(
         class = "text-muted mb-2",
         shiny::tags$i(

--- a/R/compareDashboard.R
+++ b/R/compareDashboard.R
@@ -95,7 +95,11 @@ compareDashboard <- function(.path) {
       getRevHistory(.file = pathFromLogRoot(current_file()))
     })
 
-    selection <- shiny::reactiveVal(list(ids = character(), prior = NULL, newer = NULL))
+    selection <- shiny::reactiveVal(list(
+      ids = character(),
+      prior = NULL,
+      newer = NULL
+    ))
 
     shiny::observeEvent(
       current_file(),
@@ -117,21 +121,25 @@ compareDashboard <- function(.path) {
     shiny::observeEvent(
       input$rev_clicked,
       {
-        new_ids <- update_selection(
-          selection()$ids,
-          input$rev_clicked,
-          max_sel = 2L
-        )
+        cur <- selection()
+        clicked <- as.character(input$rev_clicked)
+        new_ids <- if (length(cur$ids) >= 2L && !clicked %in% cur$ids) {
+          prior_id <- if (!is.null(cur$prior)) {
+            as.character(cur$prior)
+          } else {
+            cur$ids[1L]
+          }
+          c(setdiff(cur$ids, prior_id), clicked)
+        } else {
+          update_selection(cur$ids, clicked, max_sel = 2L)
+        }
         selection(compute_selection(new_ids))
       },
       ignoreInit = TRUE
     )
 
     output$timeline_ui <- shiny::renderUI({
-      chosen <- selection()$ids
-      sv <- svn_log()
-
-      render_timeline(sv, chosen)
+      render_timeline(svn_log(), selection())
     })
 
     output$figure_ui <- shiny::renderUI({

--- a/R/compareDashboard.R
+++ b/R/compareDashboard.R
@@ -127,7 +127,11 @@ compareDashboard <- function(.path) {
       {
         cur <- selection()
         clicked <- as.character(input$rev_clicked)
-        new_ids <- update_selection(cur$ids, clicked, max_sel = 2L)
+        new_ids <- if (length(cur$ids) >= 2L && !clicked %in% cur$ids) {
+          resolve_third_click(cur$ids, clicked, svn_log())
+        } else {
+          update_selection(cur$ids, clicked, max_sel = 2L)
+        }
         selection(compute_selection(new_ids))
       },
       ignoreInit = TRUE

--- a/R/compareDashboard.R
+++ b/R/compareDashboard.R
@@ -73,7 +73,7 @@ compareDashboard <- function(.path) {
       shiny::div(
         class = "text-muted mb-2",
         shiny::tags$i(
-          "Click two revisions to compare side by side.",
+          "Click two to compare. Older is red, newer is green.",
           style = "font-size: smaller;"
         )
       ),

--- a/R/compareDashboard.R
+++ b/R/compareDashboard.R
@@ -151,7 +151,7 @@ compareDashboard <- function(.path) {
         ))
       }
 
-      render_panel <- function(.rev, .label) {
+      render_panel <- function(.rev, .role) {
         file_path <- current_file()
         rev_file <- get_revision_file(file_path, .rev, rev_dir)
         ext <- tolower(tools::file_ext(rev_file))
@@ -162,10 +162,16 @@ compareDashboard <- function(.path) {
         }
         src <- utils::URLencode(src)
 
-        caption <- if (identical(.rev, "Local")) {
-          paste0(.label, " (Local)")
+        rev_label <- if (identical(.rev, "Local")) {
+          "Local"
         } else {
-          paste0(.label, " (Rev: ", .rev, ")")
+          paste0("Revision ", .rev)
+        }
+        caption_text <- paste0(basename(file_path), ": ", rev_label)
+        caption_style <- if (.role == "prior") {
+          "color:#991b1b; background:#fee2e2; border:1px solid #fca5a5; border-radius:6px; padding:4px 10px;"
+        } else {
+          "color:#166534; background:#dcfce7; border:1px solid #86efac; border-radius:6px; padding:4px 10px;"
         }
 
         asset <- if (ext == "png") {
@@ -185,7 +191,11 @@ compareDashboard <- function(.path) {
 
         shiny::tags$div(
           class = "fig-panel",
-          shiny::tags$div(class = "fig-caption", caption),
+          shiny::tags$div(
+            class = "fig-caption",
+            style = caption_style,
+            caption_text
+          ),
           asset
         )
       }
@@ -193,8 +203,8 @@ compareDashboard <- function(.path) {
       newer_rev <- if (is.null(p$newer)) "Local" else p$newer
 
       shiny::fluidRow(
-        shiny::column(6, render_panel(p$prior, "Older")),
-        shiny::column(6, render_panel(newer_rev, "Newer"))
+        shiny::column(6, render_panel(p$prior, "prior")),
+        shiny::column(6, render_panel(newer_rev, "newer"))
       )
     })
   }

--- a/R/diffDashboard.R
+++ b/R/diffDashboard.R
@@ -21,9 +21,13 @@ diffDashboard <- function(.file) {
 
   default_sel <- default_selection_from_log(svn_log)
 
+  sv_status <- svnStatus(dirname(fs::path_abs(.file)))
+  is_modified <- basename(.file) %in% sv_status$path[sv_status$status == "modified"]
+  title_label <- if (is_modified) "Revision Comparison: (M)" else "Revision Comparison:"
+
   # --- UI ---
   ui <- bslib::page_sidebar(
-    title = dashboard_title("Revision Comparison:", .file),
+    title = dashboard_title(title_label, .file),
     theme = bslib::bs_theme(bootswatch = "cosmo"),
     sidebar = bslib::sidebar(
       open = "always",

--- a/R/diffDashboard.R
+++ b/R/diffDashboard.R
@@ -77,11 +77,18 @@ diffDashboard <- function(.file) {
     shiny::observeEvent(
       input$rev_clicked,
       {
-        new_ids <- update_selection(
-          selection()$ids,
-          input$rev_clicked,
-          max_sel = 2L
-        )
+        cur <- selection()
+        clicked <- as.character(input$rev_clicked)
+        new_ids <- if (length(cur$ids) >= 2L && !clicked %in% cur$ids) {
+          prior_id <- if (!is.null(cur$prior)) {
+            as.character(cur$prior)
+          } else {
+            cur$ids[1L]
+          }
+          c(setdiff(cur$ids, prior_id), clicked)
+        } else {
+          update_selection(cur$ids, clicked, max_sel = 2L)
+        }
         selection(compute_selection(new_ids))
       },
       ignoreInit = TRUE
@@ -89,9 +96,7 @@ diffDashboard <- function(.file) {
 
     # --- Timeline UI (LOCAL first, then SVN revisions) ---
     output$timeline_ui <- shiny::renderUI({
-      chosen <- selection()$ids
-
-      render_timeline(svn_log, chosen)
+      render_timeline(svn_log, selection())
     })
 
     output$diff_html <- shiny::renderUI({

--- a/R/diffDashboard.R
+++ b/R/diffDashboard.R
@@ -83,12 +83,7 @@ diffDashboard <- function(.file) {
         cur <- selection()
         clicked <- as.character(input$rev_clicked)
         new_ids <- if (length(cur$ids) >= 2L && !clicked %in% cur$ids) {
-          prior_id <- if (!is.null(cur$prior)) {
-            as.character(cur$prior)
-          } else {
-            cur$ids[1L]
-          }
-          c(setdiff(cur$ids, prior_id), clicked)
+          resolve_third_click(cur$ids, clicked, svn_log)
         } else {
           update_selection(cur$ids, clicked, max_sel = 2L)
         }

--- a/R/diffDashboard.R
+++ b/R/diffDashboard.R
@@ -23,11 +23,10 @@ diffDashboard <- function(.file) {
 
   sv_status <- svnStatus(dirname(fs::path_abs(.file)))
   is_modified <- basename(.file) %in% sv_status$path[sv_status$status == "modified"]
-  title_label <- if (is_modified) "Revision Comparison: (M)" else "Revision Comparison:"
 
   # --- UI ---
   ui <- bslib::page_sidebar(
-    title = dashboard_title(title_label, .file),
+    title = dashboard_title("Revision Comparison:", .file, modified = is_modified),
     theme = bslib::bs_theme(bootswatch = "cosmo"),
     sidebar = bslib::sidebar(
       open = "always",

--- a/R/diffDashboard.R
+++ b/R/diffDashboard.R
@@ -82,11 +82,7 @@ diffDashboard <- function(.file) {
       {
         cur <- selection()
         clicked <- as.character(input$rev_clicked)
-        new_ids <- if (length(cur$ids) >= 2L && !clicked %in% cur$ids) {
-          resolve_third_click(cur$ids, clicked, svn_log)
-        } else {
-          update_selection(cur$ids, clicked, max_sel = 2L)
-        }
+        new_ids <- update_selection(cur$ids, clicked, max_sel = 2L)
         selection(compute_selection(new_ids))
       },
       ignoreInit = TRUE

--- a/R/diffDashboard.R
+++ b/R/diffDashboard.R
@@ -82,7 +82,11 @@ diffDashboard <- function(.file) {
       {
         cur <- selection()
         clicked <- as.character(input$rev_clicked)
-        new_ids <- update_selection(cur$ids, clicked, max_sel = 2L)
+        new_ids <- if (length(cur$ids) >= 2L && !clicked %in% cur$ids) {
+          resolve_third_click(cur$ids, clicked, svn_log)
+        } else {
+          update_selection(cur$ids, clicked, max_sel = 2L)
+        }
         selection(compute_selection(new_ids))
       },
       ignoreInit = TRUE

--- a/R/svnStatus.R
+++ b/R/svnStatus.R
@@ -1,0 +1,42 @@
+#' Get the SVN status of a file or directory
+#'
+#' @param .file `character(1)` path to a file or directory tracked in SVN.
+#'
+#' @return `data.frame` with columns `path` (character, basename) and
+#'   `status` (character, e.g. `"modified"`, `"unversioned"`).
+#'   Returns a zero-row data frame if the target is clean or if SVN fails.
+#' @noRd
+svnStatus <- function(.file) {
+  result <- tryCatch(
+    svnCommand(.file = .file, .command = "status"),
+    error = function(e) NULL
+  )
+  if (is.null(result)) {
+    return(data.frame(path = character(), status = character()))
+  }
+  entries <- if (is.list(result$target)) result$target else list(result$target)
+  paths <- vapply(
+    entries,
+    function(e) {
+      if (is.list(e) && !is.null(e$.attrs[["path"]])) {
+        basename(e$.attrs[["path"]])
+      } else {
+        NA_character_
+      }
+    },
+    character(1L)
+  )
+  items <- vapply(
+    entries,
+    function(e) {
+      if (is.list(e) && !is.null(e[["wc-status"]])) {
+        e[["wc-status"]][[".attrs"]][["item"]]
+      } else {
+        NA_character_
+      }
+    },
+    character(1L)
+  )
+  keep <- !is.na(paths) & !is.na(items)
+  data.frame(path = paths[keep], status = items[keep], stringsAsFactors = FALSE)
+}

--- a/R/svnStatus.R
+++ b/R/svnStatus.R
@@ -15,28 +15,20 @@ svnStatus <- function(.file) {
     return(data.frame(path = character(), status = character()))
   }
   entries <- if (is.list(result$target)) result$target else list(result$target)
-  paths <- vapply(
-    entries,
-    function(e) {
-      if (is.list(e) && !is.null(e$.attrs[["path"]])) {
-        basename(e$.attrs[["path"]])
-      } else {
-        NA_character_
-      }
-    },
-    character(1L)
-  )
-  items <- vapply(
-    entries,
-    function(e) {
-      if (is.list(e) && !is.null(e[["wc-status"]])) {
-        e[["wc-status"]][[".attrs"]][["item"]]
-      } else {
-        NA_character_
-      }
-    },
-    character(1L)
-  )
+  paths <- purrr::map_chr(entries, function(e) {
+    if (is.list(e) && !is.null(e$.attrs[["path"]])) {
+      basename(e$.attrs[["path"]])
+    } else {
+      NA_character_
+    }
+  })
+  items <- purrr::map_chr(entries, function(e) {
+    if (is.list(e) && !is.null(e[["wc-status"]])) {
+      e[["wc-status"]][[".attrs"]][["item"]]
+    } else {
+      NA_character_
+    }
+  })
   keep <- !is.na(paths) & !is.na(items)
   data.frame(path = paths[keep], status = items[keep], stringsAsFactors = FALSE)
 }

--- a/R/utils-dashboard.R
+++ b/R/utils-dashboard.R
@@ -34,6 +34,22 @@ update_selection <- function(ids, clicked, max_sel = 2L) {
   new
 }
 
+#' Resolve which selected revision to replace when a third is clicked
+#'
+#' @param ids `character(2)` currently selected revision IDs.
+#' @param clicked `character(1)` newly clicked revision ID.
+#' @param svn_log `data.frame` from `getRevHistory()`, used for positional rank.
+#'
+#' @return `character(2)` updated selection with the nearer endpoint replaced.
+#' @noRd
+resolve_third_click <- function(ids, clicked, svn_log) {
+  all_revs <- as.character(svn_log$rev)
+  rank <- stats::setNames(seq_along(all_revs), all_revs)
+  click_rank <- rank[clicked]
+  id_ranks <- rank[ids]
+  replace <- ids[which.min(abs(id_ranks - click_rank))]
+  c(setdiff(ids, replace), clicked)
+}
 
 #' Compute a paired selection (prior/newer) from selected revision IDs
 #'

--- a/R/utils-dashboard.R
+++ b/R/utils-dashboard.R
@@ -25,10 +25,10 @@ update_selection <- function(ids, clicked, max_sel = 2L) {
 
   if (clicked %in% ids) {
     new <- setdiff(ids, clicked)
-  } else if (length(ids) >= max_sel) {
-    return(ids)
   } else {
     new <- c(ids, clicked)
+    new <- new[!duplicated(new)]
+    if (length(new) > max_sel) new <- utils::tail(new, max_sel)
   }
 
   new
@@ -160,9 +160,7 @@ timeline_assets <- function(side_scroll_height, extra_css = NULL) {
     .side-scroll { max-height: ",
     side_scroll_height,
     "; overflow:auto; padding-right:4px; }
-    .rev-toast { position:fixed; bottom:24px; left:50%; transform:translateX(-50%); background:#1e293b; color:#f8fafc; padding:8px 16px; border-radius:8px; font-size:0.85rem; pointer-events:none; opacity:0; transition:opacity .2s ease; z-index:9999; white-space:nowrap; }
-    .rev-toast.show { opacity:1; }
-    ",
+",
     if (!is.null(extra_css)) extra_css else "",
     "
     "
@@ -170,28 +168,13 @@ timeline_assets <- function(side_scroll_height, extra_css = NULL) {
 
   list(
     shiny::tags$style(htmltools::HTML(base_css)),
-    shiny::tags$div(id = "rev-toast", class = "rev-toast", "Deselect a revision first"),
     shiny::tags$script(htmltools::HTML(
       "
-      (function() {
-        var toastTimer;
-        function showToast() {
-          var t = document.getElementById('rev-toast');
-          if (!t) return;
-          t.classList.add('show');
-          clearTimeout(toastTimer);
-          toastTimer = setTimeout(function(){ t.classList.remove('show'); }, 2000);
-        }
-        document.addEventListener('click', function(e){
-          var el = e.target.closest('.rev'); if(!el) return;
-          var r = el.getAttribute('data-rev');
-          if (!r) return;
-          var selected = document.querySelectorAll('.rev.sel, .rev.sel-prior, .rev.sel-newer');
-          var isSelected = el.classList.contains('sel') || el.classList.contains('sel-prior') || el.classList.contains('sel-newer');
-          if (selected.length >= 2 && !isSelected) { showToast(); return; }
-          if(window.Shiny) Shiny.setInputValue('rev_clicked', r, {priority:'event'});
-        }, true);
-      })();
+      document.addEventListener('click', function(e){
+        var el = e.target.closest('.rev'); if(!el) return;
+        var r = el.getAttribute('data-rev');
+        if(window.Shiny && r) Shiny.setInputValue('rev_clicked', r, {priority:'event'});
+      }, true);
     "
     ))
   )

--- a/R/utils-dashboard.R
+++ b/R/utils-dashboard.R
@@ -18,11 +18,11 @@
 update_selection <- function(ids, clicked, max_sel = 2L) {
   clicked <- as.character(clicked)
   ids <- as.character(ids)
-  
+
   if (length(clicked) != 1L || is.na(clicked) || !nzchar(clicked)) {
     return(ids)
   }
-  
+
   if (clicked %in% ids) {
     new <- setdiff(ids, clicked)
   } else {
@@ -30,7 +30,7 @@ update_selection <- function(ids, clicked, max_sel = 2L) {
     new <- new[!duplicated(new)]
     if (length(new) > max_sel) new <- utils::tail(new, max_sel)
   }
-  
+
   new
 }
 
@@ -73,7 +73,7 @@ compute_selection <- function(ids) {
   if (length(ids) < 2) {
     return(list(ids = ids, prior = NULL, newer = NULL))
   }
-  
+
   if ("Local" %in% ids) {
     other <- setdiff(ids, "Local")
     other_num <- suppressWarnings(as.numeric(other))
@@ -130,6 +130,12 @@ timeline_assets <- function(side_scroll_height, extra_css = NULL) {
     .rev:hover .rev-card { box-shadow:0 4px 12px rgba(15,23,42,0.08); }
     .rev.sel:before { background:#4f46e5; box-shadow:0 0 0 3px #c7d2fe; }
     .rev.sel .rev-card { border-color:#818cf8; background:#f8faff; box-shadow:0 0 0 1px rgba(99,102,241,0.16), 0 6px 16px rgba(79,70,229,0.10); }
+    .rev.sel-prior:before { background:#dc2626; box-shadow:0 0 0 3px #fecaca; }
+    .rev.sel-prior .rev-card { border-color:#f87171; background:#fff8f8; box-shadow:0 0 0 1px rgba(220,38,38,0.16),0 6px 16px rgba(220,38,38,0.10); }
+    .rev.sel-prior .rev-id { background:#fee2e2; border-color:#fca5a5; color:#991b1b; }
+    .rev.sel-newer:before { background:#16a34a; box-shadow:0 0 0 3px #bbf7d0; }
+    .rev.sel-newer .rev-card { border-color:#4ade80; background:#f0fdf4; box-shadow:0 0 0 1px rgba(22,163,74,0.16),0 6px 16px rgba(22,163,74,0.10); }
+    .rev.sel-newer .rev-id { background:#dcfce7; border-color:#86efac; color:#166534; }
     .rev-main { display:flex; gap:10px; align-items:flex-start; min-width:0; }
     .rev-avatar { width:28px; height:28px; border-radius:999px; display:flex; align-items:center; justify-content:center; flex:0 0 auto; margin-top:1px; font-size:0.82rem; font-weight:700; color:#4338ca; background:linear-gradient(135deg, #e0e7ff 0%, #c7d2fe 100%); }
     .rev-body { flex:1 1 auto; min-width:0; }
@@ -146,7 +152,9 @@ timeline_assets <- function(side_scroll_height, extra_css = NULL) {
     .badge.y { background:#e7f6ec; color:#2f8f4e; border-color:#ccebd7; }
     .badge.n { background:#f4f4f4; color:#6c757d; }
     .badge.local { background:#eef3ff; color:#0d6efd; border-color:#d8e3ff; }
-    .side-scroll { max-height: ", side_scroll_height, "; overflow:auto; padding-right:4px; }
+    .side-scroll { max-height: ",
+    side_scroll_height,
+    "; overflow:auto; padding-right:4px; }
     ",
     if (!is.null(extra_css)) extra_css else "",
     "
@@ -182,18 +190,36 @@ default_selection_from_log <- function(svn_log) {
 #' Build a timeline UI for revision selection
 #'
 #' @param svn_log `data.frame` from `getRevHistory()`.
-#' @param chosen `character()` currently selected revision IDs.
+#' @param sel `list` from `compute_selection()` with elements `ids`, `prior`, `newer`.
 #'
 #' @return `shiny::tag` timeline wrapper with revision items.
 #' @noRd
-render_timeline <- function(svn_log, chosen) {
+render_timeline <- function(svn_log, sel) {
+  chosen <- sel$ids
+  prior_id <- if (!is.null(sel$prior)) as.character(sel$prior) else NULL
+  newer_id <- if (!is.null(sel$newer)) {
+    as.character(sel$newer)
+  } else if ("Local" %in% chosen) {
+    "Local"
+  } else {
+    NULL
+  }
+
   rev_items <- lapply(seq_len(nrow(svn_log)), function(i) {
     row <- svn_log[i, ]
     qc <- if (identical(row$QCed, "Yes")) {
       shiny::span(class = "badge y", "QCed")
     }
     id <- as.character(row$rev)
-    cls <- if (id %in% chosen) "rev sel" else "rev"
+    cls <- if (!id %in% chosen) {
+      "rev"
+    } else if (!is.null(prior_id) && id == prior_id) {
+      "rev sel sel-prior"
+    } else if (!is.null(newer_id) && id == newer_id) {
+      "rev sel sel-newer"
+    } else {
+      "rev sel"
+    }
     author <- trimws(as.character(row$author))
     avatar <- substr(author, 1L, 1L)
     if (!nzchar(avatar) || is.na(avatar)) {

--- a/R/utils-dashboard.R
+++ b/R/utils-dashboard.R
@@ -34,6 +34,23 @@ update_selection <- function(ids, clicked, max_sel = 2L) {
   new
 }
 
+#' Resolve which selected revision to replace when a third is clicked
+#'
+#' @param ids `character(2)` currently selected revision IDs.
+#' @param clicked `character(1)` newly clicked revision ID.
+#' @param svn_log `data.frame` from `getRevHistory()`, used for positional rank.
+#'
+#' @return `character(2)` updated selection with the farther endpoint replaced.
+#' @noRd
+resolve_third_click <- function(ids, clicked, svn_log) {
+  all_revs <- as.character(svn_log$rev)
+  rank <- stats::setNames(seq_along(all_revs), all_revs)
+  click_rank <- rank[clicked]
+  id_ranks <- rank[ids]
+  replace <- ids[which.max(abs(id_ranks - click_rank))]
+  c(setdiff(ids, replace), clicked)
+}
+
 #' Compute a paired selection (prior/newer) from selected revision IDs
 #'
 #' @description

--- a/R/utils-dashboard.R
+++ b/R/utils-dashboard.R
@@ -25,30 +25,13 @@ update_selection <- function(ids, clicked, max_sel = 2L) {
 
   if (clicked %in% ids) {
     new <- setdiff(ids, clicked)
+  } else if (length(ids) >= max_sel) {
+    return(ids)
   } else {
     new <- c(ids, clicked)
-    new <- new[!duplicated(new)]
-    if (length(new) > max_sel) new <- utils::tail(new, max_sel)
   }
 
   new
-}
-
-#' Resolve which selected revision to replace when a third is clicked
-#'
-#' @param ids `character(2)` currently selected revision IDs.
-#' @param clicked `character(1)` newly clicked revision ID.
-#' @param svn_log `data.frame` from `getRevHistory()`, used for positional rank.
-#'
-#' @return `character(2)` updated selection with the nearer endpoint replaced.
-#' @noRd
-resolve_third_click <- function(ids, clicked, svn_log) {
-  all_revs <- as.character(svn_log$rev)
-  rank <- stats::setNames(seq_along(all_revs), all_revs)
-  click_rank <- rank[clicked]
-  id_ranks <- rank[ids]
-  replace <- ids[which.min(abs(id_ranks - click_rank))]
-  c(setdiff(ids, replace), clicked)
 }
 
 #' Compute a paired selection (prior/newer) from selected revision IDs

--- a/R/utils-dashboard.R
+++ b/R/utils-dashboard.R
@@ -160,6 +160,8 @@ timeline_assets <- function(side_scroll_height, extra_css = NULL) {
     .side-scroll { max-height: ",
     side_scroll_height,
     "; overflow:auto; padding-right:4px; }
+    .rev-toast { position:fixed; bottom:24px; left:50%; transform:translateX(-50%); background:#1e293b; color:#f8fafc; padding:8px 16px; border-radius:8px; font-size:0.85rem; pointer-events:none; opacity:0; transition:opacity .2s ease; z-index:9999; white-space:nowrap; }
+    .rev-toast.show { opacity:1; }
     ",
     if (!is.null(extra_css)) extra_css else "",
     "
@@ -168,13 +170,28 @@ timeline_assets <- function(side_scroll_height, extra_css = NULL) {
 
   list(
     shiny::tags$style(htmltools::HTML(base_css)),
+    shiny::tags$div(id = "rev-toast", class = "rev-toast", "Deselect a revision first"),
     shiny::tags$script(htmltools::HTML(
       "
-      document.addEventListener('click', function(e){
-        var el = e.target.closest('.rev'); if(!el) return;
-        var r = el.getAttribute('data-rev');
-        if(window.Shiny && r) Shiny.setInputValue('rev_clicked', r, {priority:'event'});
-      }, true);
+      (function() {
+        var toastTimer;
+        function showToast() {
+          var t = document.getElementById('rev-toast');
+          if (!t) return;
+          t.classList.add('show');
+          clearTimeout(toastTimer);
+          toastTimer = setTimeout(function(){ t.classList.remove('show'); }, 2000);
+        }
+        document.addEventListener('click', function(e){
+          var el = e.target.closest('.rev'); if(!el) return;
+          var r = el.getAttribute('data-rev');
+          if (!r) return;
+          var selected = document.querySelectorAll('.rev.sel, .rev.sel-prior, .rev.sel-newer');
+          var isSelected = el.classList.contains('sel') || el.classList.contains('sel-prior') || el.classList.contains('sel-newer');
+          if (selected.length >= 2 && !isSelected) { showToast(); return; }
+          if(window.Shiny) Shiny.setInputValue('rev_clicked', r, {priority:'event'});
+        }, true);
+      })();
     "
     ))
   )

--- a/R/utils-dashboard.R
+++ b/R/utils-dashboard.R
@@ -34,22 +34,6 @@ update_selection <- function(ids, clicked, max_sel = 2L) {
   new
 }
 
-#' Resolve which selected revision to replace when a third is clicked
-#'
-#' @param ids `character(2)` currently selected revision IDs.
-#' @param clicked `character(1)` newly clicked revision ID.
-#' @param svn_log `data.frame` from `getRevHistory()`, used for positional rank.
-#'
-#' @return `character(2)` updated selection with the farther endpoint replaced.
-#' @noRd
-resolve_third_click <- function(ids, clicked, svn_log) {
-  all_revs <- as.character(svn_log$rev)
-  rank <- stats::setNames(seq_along(all_revs), all_revs)
-  click_rank <- rank[clicked]
-  id_ranks <- rank[ids]
-  replace <- ids[which.max(abs(id_ranks - click_rank))]
-  c(setdiff(ids, replace), clicked)
-}
 
 #' Compute a paired selection (prior/newer) from selected revision IDs
 #'

--- a/R/utils-dashboard.R
+++ b/R/utils-dashboard.R
@@ -99,13 +99,18 @@ compute_selection <- function(ids) {
 #'
 #' @return `htmltools::tag` for use in a title slot.
 #' @noRd
-dashboard_title <- function(label, path) {
+dashboard_title <- function(label, path, modified = FALSE) {
+  path_text <- if (modified) {
+    paste0(fs::path_rel(path), " (M)")
+  } else {
+    fs::path_rel(path)
+  }
   htmltools::div(
     style = "display:flex; gap:.35rem; align-items:baseline; font-weight:600;",
     htmltools::span(label),
     htmltools::span(
       style = "opacity:.7; font-weight:400;",
-      fs::path_rel(path)
+      path_text
     )
   )
 }

--- a/tests/testthat/test-selection.R
+++ b/tests/testthat/test-selection.R
@@ -10,23 +10,23 @@ testthat::test_that("update_selection: adds, toggles, de-duplicates, enforces ma
   ids <- update_selection(ids, "Local")
   testthat::expect_identical(ids, c("105", "Local"))
 
-  # add third -> no-op when at capacity
+  # add third -> drops oldest (FIFO)
   ids <- update_selection(ids, "103")
-  testthat::expect_identical(ids, c("105", "Local"))
+  testthat::expect_identical(ids, c("Local", "103"))
 
   # clicking an existing id removes it (toggle off)
   ids <- update_selection(ids, "Local")
-  testthat::expect_identical(ids, c("105"))
+  testthat::expect_identical(ids, c("103"))
 
   # adding a duplicate doesn't create another copy
-  ids <- update_selection(ids, "105")
+  ids <- update_selection(ids, "103")
   testthat::expect_identical(ids, character())
 })
 
-testthat::test_that("update_selection: third click is ignored when at capacity", {
+testthat::test_that("update_selection: preserves first-occurrence order before truncation", {
   ids <- c("Local", "110")
-  ids <- update_selection(ids, "105")
-  testthat::expect_identical(ids, c("Local", "110"))
+  ids <- update_selection(ids, "105") # => c("Local","110","105") -> tail 2
+  testthat::expect_identical(ids, c("110", "105"))
 })
 
 testthat::test_that("update_selection: accepts non-character & invalid clicks gracefully", {
@@ -51,9 +51,9 @@ testthat::test_that("update_selection: configurable max_sel works", {
   ids <- update_selection(ids, "103", max_sel = 3L)
   testthat::expect_identical(ids, c("101", "102", "103"))
 
-  # adding a 4th is ignored when at capacity
+  # adding a 4th drops the oldest (FIFO)
   ids <- update_selection(ids, "104", max_sel = 3L)
-  testthat::expect_identical(ids, c("101", "102", "103"))
+  testthat::expect_identical(ids, c("102", "103", "104"))
 })
 
 testthat::test_that("compute_selection: returns NULLs when fewer than two selections", {
@@ -119,11 +119,11 @@ testthat::test_that("integration: update_selection + compute_selection behave as
   ids <- character()
   ids <- update_selection(ids, "105")
   ids <- update_selection(ids, "Local")
-  # adding a third is ignored when at capacity
+  # adding a third drops the oldest (FIFO)
   ids <- update_selection(ids, "103")
-  testthat::expect_identical(ids, c("105", "Local"))
+  testthat::expect_identical(ids, c("Local", "103"))
 
   sel <- compute_selection(ids)
-  testthat::expect_identical(sel$prior, 105)
+  testthat::expect_identical(sel$prior, 103)
   testthat::expect_true(is.null(sel$newer)) # Local implies newer is local
 })

--- a/tests/testthat/test-selection.R
+++ b/tests/testthat/test-selection.R
@@ -10,23 +10,23 @@ testthat::test_that("update_selection: adds, toggles, de-duplicates, enforces ma
   ids <- update_selection(ids, "Local")
   testthat::expect_identical(ids, c("105", "Local"))
 
-  # add third -> keeps the most recent two (tail)
+  # add third -> no-op when at capacity
   ids <- update_selection(ids, "103")
-  testthat::expect_identical(ids, c("Local", "103"))
+  testthat::expect_identical(ids, c("105", "Local"))
 
   # clicking an existing id removes it (toggle off)
   ids <- update_selection(ids, "Local")
-  testthat::expect_identical(ids, c("103"))
+  testthat::expect_identical(ids, c("105"))
 
   # adding a duplicate doesn't create another copy
-  ids <- update_selection(ids, "103")
+  ids <- update_selection(ids, "105")
   testthat::expect_identical(ids, character())
 })
 
-testthat::test_that("update_selection: preserves first-occurrence order before truncation", {
+testthat::test_that("update_selection: third click is ignored when at capacity", {
   ids <- c("Local", "110")
-  ids <- update_selection(ids, "105") # => c("Local","110","105") -> tail 2
-  testthat::expect_identical(ids, c("110", "105")) # last two kept in order they appeared
+  ids <- update_selection(ids, "105")
+  testthat::expect_identical(ids, c("Local", "110"))
 })
 
 testthat::test_that("update_selection: accepts non-character & invalid clicks gracefully", {
@@ -51,9 +51,9 @@ testthat::test_that("update_selection: configurable max_sel works", {
   ids <- update_selection(ids, "103", max_sel = 3L)
   testthat::expect_identical(ids, c("101", "102", "103"))
 
-  # adding a 4th keeps the last three
+  # adding a 4th is ignored when at capacity
   ids <- update_selection(ids, "104", max_sel = 3L)
-  testthat::expect_identical(ids, c("102", "103", "104"))
+  testthat::expect_identical(ids, c("101", "102", "103"))
 })
 
 testthat::test_that("compute_selection: returns NULLs when fewer than two selections", {
@@ -119,11 +119,11 @@ testthat::test_that("integration: update_selection + compute_selection behave as
   ids <- character()
   ids <- update_selection(ids, "105")
   ids <- update_selection(ids, "Local")
-  # adding a third keeps last 2
+  # adding a third is ignored when at capacity
   ids <- update_selection(ids, "103")
-  testthat::expect_identical(ids, c("Local", "103"))
+  testthat::expect_identical(ids, c("105", "Local"))
 
   sel <- compute_selection(ids)
-  testthat::expect_identical(sel$prior, 103)
+  testthat::expect_identical(sel$prior, 105)
   testthat::expect_true(is.null(sel$newer)) # Local implies newer is local
 })

--- a/tests/testthat/test-svnStatus.R
+++ b/tests/testthat/test-svnStatus.R
@@ -1,0 +1,28 @@
+with_demoRepo({
+  test_that("svnStatus returns a data frame with expected columns", {
+    s <- svnStatus("deliv/figure")
+    expect_s3_class(s, "data.frame")
+    expect_named(s, c("path", "status"))
+    expect_type(s$path, "character")
+    expect_type(s$status, "character")
+  })
+
+  test_that("svnStatus detects modified files", {
+    s <- svnStatus("deliv/figure")
+    expect_true("example-pdf1.pdf" %in% s$path)
+    modified <- s$path[s$status == "modified"]
+    expect_true("example-pdf1.pdf" %in% modified)
+  })
+
+  test_that("svnStatus detects unversioned files", {
+    s <- svnStatus("deliv/figure")
+    unversioned <- s$path[s$status == "unversioned"]
+    expect_true("example-pdf4.pdf" %in% unversioned)
+  })
+
+  test_that("svnStatus returns zero-row data frame for a clean directory", {
+    s <- svnStatus("script/pk")
+    expect_s3_class(s, "data.frame")
+    expect_equal(nrow(s), 0L)
+  })
+})


### PR DESCRIPTION
#  Summary

  This branch improves the revision selection UX across both diffDashboard() and compareDashboard(), adds a new svnStatus() helper, and brings the two dashboards into closer visual and behavioral consistency.

#  Selection UX (diffDashboard + compareDashboard)

  Previously, both selected timeline cards looked identical (indigo), giving no indication of which revision was the "prior" vs "newer" side of the comparison. Third-click behavior was also unpredictable.

  Changes:
  - Selected cards are now color-coded to match the diff output — red for prior (older), green for newer. A single selected card stays neutral indigo until the pair is resolved.
  - Third-click behavior uses FIFO: the oldest-selected revision is dropped, keeping the two most recently clicked. This is consistent and predictable regardless of which revisions are
  selected.
  - Hint text in both dashboards reads consistently: "Click two to compare. Older is red, newer is green."

#  compareDashboard figure panel headings

  Panel captions now read filename.pdf: Revision 85 styled with a red pill for prior, green pill for newer — matching the timeline card colors.

#  Local modification indicators (svnStatus)

  - New svnStatus() helper wraps svn status --xml via the existing svnCommand() infrastructure and returns a tidy data.frame of path/status pairs, following the svnInfo/svnLog/svnExport
  pattern. Falls back to an empty data frame if SVN is unavailable.
  - diffDashboard() appends (M) after the filename in the title when the target file is locally modified.
  - compareDashboard() appends (M) to filenames in the figure dropdown for locally modified figures.
  - svnStatus() is covered by 4 tests via with_demoRepo().
