### PR TITLE
Avoid shell when calling commands

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Imports:
     htmltools,
     shiny,
     pdftools,
+    processx,
     stringi,
     here,
     purrr

--- a/R/demoRepo.R
+++ b/R/demoRepo.R
@@ -86,7 +86,7 @@ demoRepo <- function(.project_name) {
   logCreate()
   
   # Check everything into SVN
-  system("svn add * -q -q")
+  system("svn add --force -q .")
   system(glue::glue("svn commit -m 'initial commit' -q -q"))
   
   # Assign and accept scripts in QC log

--- a/R/demoRepo.R
+++ b/R/demoRepo.R
@@ -26,7 +26,7 @@ demoRepo <- function(.project_name) {
   }
   
   # Create svn repo at specified locations
-  system(glue::glue("svnadmin create {repoInitPath}"))
+  processx::run("svnadmin", c("create", repoInitPath))
   
   repoDir <- file.path(repoInitPath, .project_name)
   

--- a/R/demoRepo.R
+++ b/R/demoRepo.R
@@ -34,7 +34,7 @@ demoRepo <- function(.project_name) {
     fs::dir_delete(repoDir)
   }
   
-  system(glue::glue("svn co file://{repoInitPath} {repoDir} -q"))
+  svnRun("co", paste0("file://", repoInitPath), repoDir)
   
   setwd(repoDir)
   
@@ -86,8 +86,8 @@ demoRepo <- function(.project_name) {
   logCreate()
   
   # Check everything into SVN
-  system("svn add --force -q .")
-  system(glue::glue("svn commit -m 'initial commit' -q -q"))
+  svnRun("add", "--force", ".")
+  svnRun("commit", "-m", "initial commit")
   
   # Assign and accept scripts in QC log
   logAssign("script/data-assembly.R")
@@ -95,14 +95,14 @@ demoRepo <- function(.project_name) {
   logAssign("script/combine-da.R")
   logAssign("script/examp-txt.txt")
   
-  system(glue::glue("svn commit -m 'logAssign scripts ready for QC' -q -q"))
+  svnRun("commit", "-m", "logAssign scripts ready for QC")
   
   logAccept("script/data-assembly.R")
   logAccept("script/pk/load-spec.R")
   logAccept("script/combine-da.R")
   
   # Check in updates to QC log
-  system(glue::glue("svn commit -m 'logAccept scripts after QC' -q -q"))
+  svnRun("commit", "-m", "logAccept scripts after QC")
   
   # Make edits to QCed file
   writeLines(
@@ -110,7 +110,7 @@ demoRepo <- function(.project_name) {
     "script/pk/load-spec.R"
   )
   
-  system(glue::glue("svn commit -m 'modify load-spec script' -q -q"))
+  svnRun("commit", "-m", "modify load-spec script")
   
   writeLines(
     c(
@@ -127,7 +127,7 @@ demoRepo <- function(.project_name) {
     ),
     "script/data-assembly.R"
   )
-  system(glue::glue("svn commit -m 'modify data-assembly' -q -q"))
+  svnRun("commit", "-m", "modify data-assembly")
   
   writeLines(
     c("The following tasks are suggested to gain familiarity with the review package:",
@@ -182,13 +182,16 @@ demoRepo <- function(.project_name) {
     dir = "deliv/table"
   )
   
-  system("svn add 'deliv/figure/example-pdf1.pdf' -q -q")
-  system("svn add 'deliv/figure/example png1.png' -q -q")
-  system("svn add 'deliv/figure/example-pdf2.pdf' -q -q")
-  system("svn add 'deliv/figure/example-pdf3.pdf' -q -q")
-  system("svn add 'deliv/table/example-table-1.tex' -q -q")
-  system("svn add 'deliv/table/example-table-long-1.tex' -q -q")
-  system(glue::glue("svn commit -m 'add pdf' -q -q"))
+  svnRun(
+    "add",
+    "deliv/figure/example-pdf1.pdf",
+    "deliv/figure/example png1.png",
+    "deliv/figure/example-pdf2.pdf",
+    "deliv/figure/example-pdf3.pdf",
+    "deliv/table/example-table-1.tex",
+    "deliv/table/example-table-long-1.tex"
+  )
+  svnRun("commit", "-m", "add pdf")
   
   Sys.sleep(1)
   

--- a/R/diffQced.R
+++ b/R/diffQced.R
@@ -30,7 +30,7 @@ diffQced <- function(.file,
   
   up_to_date <-
     tryCatch(
-      svnCommand("status", .file, "-u"),
+      svnXML("status", "-u", .file),
       error = identity
     )
   

--- a/R/fileSummary.R
+++ b/R/fileSummary.R
@@ -76,7 +76,7 @@ fileSummary <- function(.file, .return_df = FALSE) {
   }
   
   log_df <- tryCatch(
-    svnCommand(.file = .file, .command = "log"),
+    svnXML("log", .file),
     error = identity
   )
   

--- a/R/getPreviousCurrent.R
+++ b/R/getPreviousCurrent.R
@@ -18,7 +18,7 @@ getPreviousCurrent <- function(.file, .previous_revision, .current_revision){
     
     .current_revision_temp_file <- tempfile(fileext = glue::glue(".{tools::file_ext(.file)}"))
     
-    system(glue::glue("cp {.file} {.current_revision_temp_file}"))
+    fs::file_copy(.file, .current_revision_temp_file)
     
     .current_revision_header <- glue::glue("{basename(.file)}: Local")
     

--- a/R/repoHistory.R
+++ b/R/repoHistory.R
@@ -7,16 +7,7 @@
 #'
 #' @export
 repoHistory <- function() {
-  
-  svn_log_v <- tryCatch(
-    svnCommand("log", .flags = "-v"),
-    error = identity
-  )
-  
-  if (inherits(svn_log_v, "error")) {
-    stop("svn log failed")
-  }
-  
+  svn_log_v <- svnXML("log", "-v")
   svn_log_df <-
     dplyr::bind_rows(svn_log_v) %>% 
     tidyr::unnest(paths) %>% 

--- a/R/repoInfo.R
+++ b/R/repoInfo.R
@@ -1,4 +1,0 @@
-#' @keywords internal
-repoInfo <- function(file=logRoot()) {
-  paste(system(paste("svn info --xml",file),intern=TRUE),collapse="")
-}

--- a/R/revision.R
+++ b/R/revision.R
@@ -1,12 +1,10 @@
 #' @keywords internal
 revision <- function(file=logRoot()){
-	hasSpace <- regexpr(' ',file) > 0
-	isQuoted <- regexpr('^["\']',file) > 0
-	if(hasSpace & !isQuoted) file <- paste("'",file,"'",sep='')
-	text <- repoInfo(file)
-	x <- XML::xmlTreeParse(text,asText=TRUE)
-	y <- x$doc$children$info[["entry"]][["commit"]]$attributes[["revision"]]
-	if(is.null(y))y <- NA
-	as.numeric(y)
+  info <- svnXML("info", file)
+  rev <- info[["entry"]][["commit"]][[".attrs"]][["revision"]]
+  if (is.null(rev)) {
+    return(NA_real_)
+  }
+  return(as.numeric(rev))
 }
 

--- a/R/svnExport.R
+++ b/R/svnExport.R
@@ -24,7 +24,9 @@ svnExport <- function(.file, .revision = NULL, .output_dir = getwd(), .return_fi
   }
   
   if (is.null(.revision)) {
-    .revision <- as.numeric(svnInfo(.file = .file)[["rev"]])
+    .revision <- svnInfo(.file = .file)[["rev"]]
+  } else {
+    .revision <- as.character(.revision)
   }
   
   .file_rev_path <- 
@@ -38,24 +40,10 @@ svnExport <- function(.file, .revision = NULL, .output_dir = getwd(), .return_fi
         tools::file_ext(.file)
       )
     )
-  
-  # Add the single quotes in between the files
-  # svnCommand will add the outer quotes
-  .file_command <- paste0(.file, "' '", .file_rev_path)
-  
-  export_try <- tryCatch(
-    svnCommand(
-      .file = .file_command,
-      .command = "export",
-      .flags = paste0("--force -r", .revision),
-      .xml = FALSE
-    ),
-    error = identity
+
+  svnRun(
+    "export", "--force", "-r", .revision, .file, .file_rev_path
   )
-  
-  if (inherits(export_try, "error")) {
-    stop("svn export failed")
-  }
   
   if (!.quiet) {
     cli::cli_inform(paste0("File exported: ", .file_rev_path))

--- a/R/svnHelpers.R
+++ b/R/svnHelpers.R
@@ -1,3 +1,23 @@
+#' Run 'svn ...' for side-effects.
+#'
+#' Standard output is discarded, and standard error is displayed only when an
+#' error is signaled.
+#'
+#' @param ... Arguments passed to svn.
+#' @noRd
+svnRun <- function(...) {
+  args <- purrr::flatten_chr(list(...))
+  processx::run(
+    command = "svn",
+    args = args,
+    echo = FALSE,
+    stdout = NULL,
+    error_on_status = TRUE
+  )
+
+  return(invisible(NULL))
+}
+
 #' @noRd
 svnCommand <- function(.command, .file = NULL, .flags = NULL, .quiet = TRUE, .xml = TRUE) {
   

--- a/R/svnHelpers.R
+++ b/R/svnHelpers.R
@@ -18,29 +18,19 @@ svnRun <- function(...) {
   return(invisible(NULL))
 }
 
+#' Run 'svn {subcommand} --xml ...', returning the parsed XML as a list.
+#'
+#' @param subcommand An svn subcommand.
+#' @param ... Arguments passed to the subcommand.
 #' @noRd
-svnCommand <- function(.command, .file = NULL, .flags = NULL, .quiet = TRUE, .xml = TRUE) {
-  
-  command_run <- paste("svn",
-                       .command,
-                       .flags,
-                       ifelse(.xml, "--xml", ""),
-                       paste0("'", .file, "'"),
-                       ifelse(.quiet, "2>/dev/null", ""),
-                       sep = " ")
-  
-  temp_loc <- system(command_run, intern = TRUE) %>% suppressWarnings()
-  
-  if (!is.null(attr(temp_loc, "status"))) {
-    stop("svn command failed")
-  }
-  
-  if (!.xml) {
-    return(invisible(NULL))
-  }
-  
-  parsed_results <- XML::xmlParse(temp_loc)
-  list_results <- XML::xmlToList(parsed_results)
-  
-  list_results
+svnXML <- function(subcommand, ...) {
+  args <- c(subcommand, "--xml", purrr::flatten_chr(list(...)))
+  proc <- processx::run(
+    command = "svn",
+    args = args,
+    error_on_status = TRUE,
+  )
+  out <- proc[["stdout"]]
+
+  return(XML::xmlToList(XML::xmlParse(out)))
 }

--- a/R/svnInfo.R
+++ b/R/svnInfo.R
@@ -7,16 +7,7 @@
 #' 
 #' @noRd
 svnInfo <- function(.file){
-  
-  info_list <- tryCatch(
-    svnCommand(.file = .file, .command = "info"),
-    error = identity
-  )
-  
-  if (inherits(info_list, "error")) {
-    stop("svn info failed")
-  }
-  
+  info_list <- svnXML("info", .file)
   info_return <- 
     dplyr::bind_rows(info_list$entry$commit) %>% 
     dplyr::rename(rev = .attrs) %>% 

--- a/R/svnList.R
+++ b/R/svnList.R
@@ -5,16 +5,7 @@
 #' 
 #' @noRd
 svnList <- function(){
-  
-  svn_list <- tryCatch(
-    svnCommand("list", .flags = "--depth infinity"),
-    error = identity
-  )
-  
-  if (inherits(svn_list, "error")) {
-    stop("svn list failed")
-  }
-  
+  svn_list <- svnXML("list", "--depth", "infinity")
   list_return <- 
     dplyr::bind_rows(svn_list$list) %>% 
     tidyr::unnest(commit) %>% 

--- a/R/svnLog.R
+++ b/R/svnLog.R
@@ -12,16 +12,7 @@
 #' 
 #' @export
 svnLog <- function(.file) {
-  
-  log_df <- tryCatch(
-    svnCommand(.file = .file, .command = "log"),
-    error = identity
-  )
-  
-  if (inherits(log_df, "error")) {
-    stop("svn log failed")
-  }
-  
+  log_df <- svnXML("log", .file)
   log_return <- 
     dplyr::bind_rows(log_df) %>% 
     dplyr::rename(rev = .attrs) %>% 

--- a/R/svnProjInfo.R
+++ b/R/svnProjInfo.R
@@ -7,16 +7,7 @@
 #' 
 #' @noRd
 svnProjInfo <- function(.host_name = "mc1.metrumrg.com"){
-  
-  info_list <- tryCatch(
-    svnCommand(.command = "info"),
-    error = identity
-  )
-  
-  if (inherits(info_list, "error")) {
-    stop("svn info failed")
-  }
-  
+  info_list <- svnXML("info")
   svn_url <- info_list$entry$url
   svn_rev <- as.numeric(info_list$entry$commit$.attrs)
   

--- a/R/svnStatus.R
+++ b/R/svnStatus.R
@@ -8,7 +8,7 @@
 #' @noRd
 svnStatus <- function(.file) {
   result <- tryCatch(
-    svnCommand(.file = .file, .command = "status"),
+    svnXML("status", .file),
     error = function(e) NULL
   )
   if (is.null(result)) {

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -20,10 +20,10 @@ create_test_svn <- function(.user_lookup = user_lookup) {
   
   remote_repo_local <- paste0(tempdir(), "/test")
   
-  .command <-
-    glue::glue("svn co svn+ssh://{this_user}@mc1-test.metrumrg.com/common/repo/svn-proj-review-tests {remote_repo_local} -q -q")
-  
-  system(.command)
+  url <- glue::glue(
+    "svn+ssh://{this_user}@mc1-test.metrumrg.com/common/repo/svn-proj-review-tests"
+  )
+  svnRun("co", url, remote_repo_local)
   
   setwd(remote_repo_local)
 }

--- a/tests/testthat/test-svnHelpers.R
+++ b/tests/testthat/test-svnHelpers.R
@@ -1,10 +1,10 @@
 with_demoRepo({
   file1 <- "script/data-assembly.R"
   
-  logList <- svnCommand(.file = file1, .command = "log")
-  infoList <- svnCommand(.file = file1, .command = "info")
+  logList <- svnXML("log", file1)
+  infoList <- svnXML("info", file1)
   
-  test_that("svnCommand has a list output and expected size of entries", {
+  test_that("svnXML has a list output and expected size of entries", {
     expect_equal(length(logList), 2)
     expect_equal(length(infoList), 1)
     expect_true(all(c("author", "date", ".attrs") %in% names(logList$logentry)))
@@ -12,12 +12,12 @@ with_demoRepo({
     expect_true(all(c("author", "date", ".attrs") %in% names(infoList$entry$commit)))
   })
   
-  test_that("svnCommand identifies 2 changes to the file in the log output", {
+  test_that("svnXML identifies 2 changes to the file in the log output", {
     expect_true(as.numeric(logList[2]$logentry$.attrs) == 1)
     expect_true(as.numeric(logList[1]$logentry$.attrs) == 5)
   })
   
-  test_that("svnCommand identifies most recent revision in svn info", {
+  test_that("svnXML identifies most recent revision in svn info", {
     expect_true(infoList$entry$.attrs[["revision"]] == "5")
   })
 })


### PR DESCRIPTION
This PR moves from using the shell-based `system` to the non-shell based `processx::run`.  That enables getting rid of some brittle (and not fully effective) file name quoting kludges.  (It also removes the possibility of shell injection, though that's not much of a concern in this context, where the input is trusted.)

`svnCommand` is replaced by two new wrappers, `svnXML` (for caling an svn subcommand with `--xml` and returning the parsed output) and `svnRun` (for running the command for side-effects, discarding the standard output and only showing the standard error on failure).

This has a semantic conflict with gh-207.  That can be resolved with the change below.

<details>
<summary>diff</summary>

```diff
diff --git a/R/logRename.R b/R/logRename.R
index 75b3294..77179c6 100644
--- a/R/logRename.R
+++ b/R/logRename.R
@@ -43,8 +43,7 @@ logRename <- function(.filepath, .new_filepath) {
     )
   }
 
-  # svnCommand adds the outer quotes; these quotes separate the two paths.
-  svnCommand("mv", paste0(old_path, "' '", new_path), .xml = FALSE)
+  svnRun("mv", old_path, new_path)
 
   qclog$file[qclog$file %in% old] <- new
   qclog$origin[qclog$origin %in% old] <- new
```

</details>


Re: https://github.com/metrumresearchgroup/review/pull/207#discussion_r3806501778

---

I'll leave this as draft because running the full test suite may flag some issues that need to be addressed, but this is ready for review.

- [x] Confirm the full test suite passes
